### PR TITLE
Imaging data conversion

### DIFF
--- a/example_usage.ipynb
+++ b/example_usage.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test the implementation of Abdeladim_2023 Imaging Interface on mouseV1 data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from src.mousev1_to_nwb.abdeladim_2023.abdeladim_2023imaginginterface import Abdeladim2023SinglePlaneImagingInterface\n",
+    "\n",
+    "root_path = Path(f\"/media/amtra/Samsung_T5/CN_data/MouseV1-to-nwb\")\n",
+    "session_id = \"7expt\"  # \"2ret\",\"3ori\",\"4ori\",\"5stim\",\"6stim\",\"7expt\"\n",
+    "imaging_path = root_path / \"raw-tiffs\" / session_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "channel = \"Channel 1\" #\"Channel 2\"\n",
+    "plane = \"0\" # \"1\",\"2\"\n",
+    "interface = Abdeladim2023SinglePlaneImagingInterface(\n",
+    "    folder_path=imaging_path, channel_name=channel, plane_name=plane\n",
+    ")\n",
+    "image_metadata = interface.get_metadata()\n",
+    "image_metadata"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mousev1_lab_to_nwb_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/mousev1_to_nwb/abdeladim_2023/__init__.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/__init__.py
@@ -1,2 +1,0 @@
-from .abdeladim_2023behaviorinterface import Abdeladim2023BehaviorInterface
-from .abdeladim_2023nwbconverter import Abdeladim2023NWBConverter

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # Parameters for conversion
     root_path = Path(f"/media/amtra/Samsung_T5/CN_data")
     data_dir_path = root_path / "MouseV1-to-nwb"
-    output_dir_path = root_path / "MouseV1-to-nwb-conversion_nwb/"
+    output_dir_path = root_path / "MouseV1-conversion_nwb/"
     stub_test = True
     session_id = "7expt"  # "2ret","3ori","4ori","5stim","6stim","7expt"
 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
@@ -7,9 +7,7 @@ from zoneinfo import ZoneInfo
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
-from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextractor import (
-    ScanImageTiffSinglePlaneImagingExtractor,
-)
+from abdeladim_2023imaginginterface import Abdeladim2023SinglePlaneImagingInterface
 from abdeladim_2023nwbconverter import Abdeladim2023NWBConverter
 
 
@@ -29,9 +27,8 @@ def session_to_nwb(
 
     # Add Imaging
     imaging_path = data_dir_path / "raw-tiffs" / session_id
-    tif_files = sorted(glob.glob(f"{imaging_path}/*.tif"))
-    available_channels = ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=tif_files[0])
-    available_planes = ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=tif_files[0])
+    available_channels = Abdeladim2023SinglePlaneImagingInterface.get_available_channels(folder_path=imaging_path)
+    available_planes = Abdeladim2023SinglePlaneImagingInterface.get_available_planes(folder_path=imaging_path)
     photon_series_index = 0
     for channel in available_channels:
         for plane in available_planes:

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
@@ -62,6 +62,11 @@ def session_to_nwb(
     editable_metadata_path = Path(__file__).parent / "abdeladim_2023_metadata.yaml"
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
+
+    # Add the correct metadata for the session
+    timezone = ZoneInfo("America/Los_Angeles")  # Time zone for Berkeley, California
+    session_start_time = metadata["NWBFile"]["session_start_time"]
+    metadata["NWBFile"].update(session_start_time=session_start_time.replace(tzinfo=timezone))
     metadata["Subject"].update(subject_id=subject_id)
     metadata["NWBFile"].update(session_id=session_id)
     # Run conversion
@@ -75,9 +80,9 @@ if __name__ == "__main__":
     root_path = Path(f"/media/amtra/Samsung_T5/CN_data")
     data_dir_path = root_path / "MouseV1-to-nwb"
     output_dir_path = root_path / "MouseV1-conversion_nwb/"
-    stub_test = True
+    stub_test = False #for some reason does not work for iamging data
 
-    epoch_index = 0
+    epoch_index = 3
     epochs_name = ["2ret", "3ori", "4ori", "5stim", "6stim", "7expt"]
     session_id = epochs_name[epoch_index]
 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
@@ -12,14 +12,13 @@ from abdeladim_2023nwbconverter import Abdeladim2023NWBConverter
 from abdeladim_2023nwbconverter import get_default_segmentation_to_imaging_name_mapping
 
 def session_to_nwb(
-    data_dir_path: Union[str, Path], output_dir_path: Union[str, Path], session_id: str, stub_test: bool = False
+    data_dir_path: Union[str, Path], output_dir_path: Union[str, Path], session_id: str, subject_id:str, stub_test: bool = False
 ):
     data_dir_path = Path(data_dir_path)
     output_dir_path = Path(output_dir_path)
     if stub_test:
         output_dir_path = output_dir_path / "nwb_stub"
     output_dir_path.mkdir(parents=True, exist_ok=True)
-    subject_id = "unknown"  # TODO ask for subject_id
     nwbfile_path = output_dir_path / f"{session_id}.nwb"
 
     # Add Imaging
@@ -53,6 +52,7 @@ def session_to_nwb(
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
     metadata["Subject"].update(subject_id=subject_id)
+    metadata["NWBFile"].update(session_id=session_id)
     # Run conversion
     converter.run_conversion(
         metadata=metadata, 
@@ -69,10 +69,12 @@ if __name__ == "__main__":
     output_dir_path = root_path / "MouseV1-conversion_nwb/"
     stub_test = True
     session_id = "7expt"  # "2ret","3ori","4ori","5stim","6stim","7expt"
+    subject_id = "unknown"  # TODO ask for subject_id
 
     session_to_nwb(
         data_dir_path=data_dir_path,
         output_dir_path=output_dir_path,
         session_id=session_id,
+        subject_id=subject_id,
         stub_test=stub_test,
     )

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
@@ -1,71 +1,80 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 from pathlib import Path
 from typing import Union
+import glob
 import datetime
 from zoneinfo import ZoneInfo
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
-from mousev1_to_nwb.abdeladim_2023 import Abdeladim2023NWBConverter
+from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextractor import (
+    ScanImageTiffSinglePlaneImagingExtractor,
+)
+from abdeladim_2023nwbconverter import Abdeladim2023NWBConverter
 
 
-def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, Path], stub_test: bool = False):
-
+def session_to_nwb(
+    data_dir_path: Union[str, Path], output_dir_path: Union[str, Path], session_id: str, stub_test: bool = False
+):
     data_dir_path = Path(data_dir_path)
     output_dir_path = Path(output_dir_path)
     if stub_test:
         output_dir_path = output_dir_path / "nwb_stub"
     output_dir_path.mkdir(parents=True, exist_ok=True)
-
-    session_id = "subject_identifier_usually"
+    subject_id = "unknown"  # TODO ask for subject_id
     nwbfile_path = output_dir_path / f"{session_id}.nwb"
 
     source_data = dict()
     conversion_options = dict()
 
-    # Add Recording
-    source_data.update(dict(Recording=dict()))
-    conversion_options.update(dict(Recording=dict()))
-
-    # Add LFP
-    source_data.update(dict(LFP=dict()))
-    conversion_options.update(dict(LFP=dict()))
-
-    # Add Sorting
-    source_data.update(dict(Sorting=dict()))
-    conversion_options.update(dict(Sorting=dict()))
-
-    # Add Behavior
-    source_data.update(dict(Behavior=dict()))
-    conversion_options.update(dict(Behavior=dict()))
+    # Add Imaging
+    imaging_path = data_dir_path / "raw-tiffs" / session_id
+    tif_files = sorted(glob.glob(f"{imaging_path}/*.tif"))
+    available_channels = ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=tif_files[0])
+    available_planes = ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=tif_files[0])
+    photon_series_index = 0
+    for channel in available_channels:
+        for plane in available_planes:
+            channel_name_without_space = channel.replace(" ", "")
+            interface_name = f"Imaging{channel_name_without_space}Plane{plane}"
+            source_data[interface_name] = {
+                "folder_path": str(imaging_path),
+                "channel_name": channel,
+                "plane_name": plane,
+            }
+            conversion_options[interface_name] = {"stub_test": stub_test, "photon_series_index": photon_series_index}
+            photon_series_index += 1
 
     converter = Abdeladim2023NWBConverter(source_data=source_data)
 
     # Add datetime to conversion
     metadata = converter.get_metadata()
-    datetime.datetime(
-        year=2020, month=1, day=1, tzinfo=ZoneInfo("US/Eastern")
-    )
-    date = datetime.datetime.today()  # TO-DO: Get this from author
-    metadata["NWBFile"]["session_start_time"] = date
 
     # Update default metadata with the editable in the corresponding yaml file
     editable_metadata_path = Path(__file__).parent / "abdeladim_2023_metadata.yaml"
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
-
+    metadata = dict_deep_update(metadata, {"Subject": {"subject_id": subject_id}})
     # Run conversion
-    converter.run_conversion(metadata=metadata, nwbfile_path=nwbfile_path, conversion_options=conversion_options)
+    converter.run_conversion(
+        metadata=metadata, 
+        nwbfile_path=nwbfile_path, 
+        conversion_options=conversion_options, 
+        overwrite=True
+    )
 
 
 if __name__ == "__main__":
-
     # Parameters for conversion
-    data_dir_path = Path("/Directory/With/Raw/Formats/")
-    output_dir_path = Path("~/conversion_nwb/")
-    stub_test = False
+    root_path = Path(f"/media/amtra/Samsung_T5/CN_data")
+    data_dir_path = root_path / "MouseV1-to-nwb"
+    output_dir_path = root_path / "MouseV1-to-nwb-conversion_nwb/"
+    stub_test = True
+    session_id = "7expt"  # "2ret","3ori","4ori","5stim","6stim","7expt"
 
-    session_to_nwb(data_dir_path=data_dir_path,
-                    output_dir_path=output_dir_path,
-                    stub_test=stub_test,
-                    )
+    session_to_nwb(
+        data_dir_path=data_dir_path,
+        output_dir_path=output_dir_path,
+        session_id=session_id,
+        stub_test=stub_test,
+    )

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
@@ -52,7 +52,7 @@ def session_to_nwb(
     editable_metadata_path = Path(__file__).parent / "abdeladim_2023_metadata.yaml"
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
-    metadata = dict_deep_update(metadata, {"Subject": {"subject_id": subject_id}})
+    metadata["Subject"].update(subject_id=subject_id)
     # Run conversion
     converter.run_conversion(
         metadata=metadata, 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_convert_session.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     output_dir_path = root_path / "MouseV1-conversion_nwb/"
     stub_test = True
     session_id = "7expt"  # "2ret","3ori","4ori","5stim","6stim","7expt"
-    subject_id = "unknown"  # TODO ask for subject_id
+    subject_id = "unknown"  # "w51_1", "w57_1"
 
     session_to_nwb(
         data_dir_path=data_dir_path,

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_metadata.yaml
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_metadata.yaml
@@ -1,14 +1,16 @@
 NWBFile:
   related_publications:
-    https://doi.org/### or link to APA or MLA citation of the publication
+    - https://www.biorxiv.org/content/10.1101/2023.03.02.530875v2.full
+    - https://www.biorxiv.org/content/10.1101/2022.09.20.508739v1.full
+    - https://www.sciencedirect.com/science/article/pii/S2211124723009208
   session_description:
     A rich text description of the experiment. Can also just be the abstract of the publication.
   institution: Institution where the lab is located
   lab: Mousev1
   experimenter:
-    - Last, First Middle
-    - Last, First Middle
+    - Abdeladim, Lamiae
+    - Adesnik, Hillel
 Subject:
   species: Rattus norvegicus
-  age: TBD  # in ISO 8601, such as "P1W2D"
-  sex: TBD  # One of M, F, U, or O
+  age: P1W2D  #TODO check
+  sex: U  #TODO check

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_notes.md
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_notes.md
@@ -35,7 +35,19 @@ https://www.sciencedirect.com/science/article/pii/S2211124723009208
 
 **From [Paper3](https://www.sciencedirect.com/science/article/pii/S2211124723009208):**
 
-**From Data exploraton:**
+### Data exploraton:
+#### Imaging data (ScanImage):
+
+**General checks**
+
+-[x] Each tif. file in the session folder hase the same starting session datetime and sampling frequency
+-[x] Regular sampling frequency over the timestamps extracted from all files in the session folder. NB: extract timestamp as in line 164-166 scanimagetiddimagingextractor.py --> **No regular sampling frequency** 
+In particular, some of the .tif file have regular timestamps (round robin 19.0686 Hz, circa 6.35 Hz per slice), some not.
+--> save timestamps not sampling frequency? (option not implemented in Scan Image interface/extractor)
+--> the sampling frequency currently extracted in scan image extratctor is referred to the round robin frequency not the one of single channel acquisition
+--> does the extractor account for dropped frames? 
+-------------------------------------
+**FOLLOWING: is all taken care by ScanImage interface and extractor**
 - imaging data (ScanImage): 
     - shape of image on a single tif (open with tifffile): n_volumes:96, n_channels:2, n_xpixels:512, n_ypixels:512 (sometimes 93 not 96). 
     NB: From [ScanImage](https://docs.scanimage.org/Concepts/Volume+Imaging.html?highlight=frames+per+volume) doc
@@ -63,6 +75,8 @@ https://www.sciencedirect.com/science/article/pii/S2211124723009208
         - SI.hStackManager.actualNumVolumes : 100
         - SI.hStackManager.actualStackZStepSize : 30
         - SI.hStackManager.framesPerSlice : 1
+---------------------------
+
 
 - segmentation (Suite2P), #TODO
 ## Data organisation: 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_notes.md
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_notes.md
@@ -108,6 +108,71 @@ NB: for `stim_id`=4 --> `hologram_list[3]` is nan <span style="color: red;">why?
 #### ROIs indices
 In the example.hdf5 file the targeted cells are 368 (`len(targeted_cells)`) in total, both for 5stim and 7expt. `targeted_cells` value span from 0 to 700 (`np.nanmax(targeted_cells)`).
 If we sum the number of cells ideatified as true cells in Suite2p over the 3 plane we obtain 702 cells (`len(iscell_0[iscell_0[:,0]!=0.])+len(iscell_1[iscell_1[:,0]!=0.])+len(iscell_2[iscell_2[:,0]!=0.])`). 
+
+In the ScanImage .tif metadata there is a dictonary saved as text that the function `extract_extra_metadata` cannot parse, where information on the ROIs are stored. 
+```
+"RoiGroups":{
+    "imagingRoiGroup":{# general imaging space metadata (only 2D)
+        ...
+        "centerXY": [-1.776356839e-16,0.1],
+        "sizeXY": [13.5,13.5], # size of the FOV 
+        "rotationDegrees": 0,
+        "enable": 1,
+        "pixelResolutionXY": [512,512],
+        "pixelToRefTransform": [[0.0263671875,0,-6.763183594],
+                                [0,0.263671875,-6.663183594],
+                                [0,0,1]],
+        "affine":  [[13.5,0,-6.75],
+                    [0,13.5,-6.65],
+                    [0,0,1]]
+        ...
+    }, 
+    "photostimRoiGroups":null, # no spatial info on photostimRoiGroups
+    "integrationRoiGroup":{
+        ...
+        "rois": [
+        {
+          "ver": 1,
+          "classname": "scanimage.mroi.Roi",
+          "name": "ROI 1",
+            ...
+          "zs": 0,
+          "scanfields": {
+            ...
+            "centerXY": [2.518066406,1.062402344],
+            "sizeXY": [0.2373046875,0.2373046875],
+            "rotationDegrees": 0,
+            "enable": 1,
+            "threshold": 100,
+            "channel": 1,
+            "processor": "cpu",
+            "mask": [roi_pixel_mask 9x9 binary matrix],
+            "affine": [[0.2373046875,0,2.518066406],
+                       [0,0.2373046875,1.062402344],
+                       [0,0,1]]
+          },
+          "discretePlaneMode": 1,
+          "powers": null,
+          "pzAdjust": null,
+          "Lzs": null,
+          "interlaceDecimation": null,
+          "interlaceOffset": null,
+          "enable": 1
+        },
+        ... # all the 368 ROIs
+        ]
+    } # imaging space metadata for each ROI
+}
+```
+In `imagingRoiGroup` we can probably extract info on the dimension of the field of view (XY) from `"sizeXY"` and divide by the dimension to get the grid_spacing (z dimension missed)
+
+In `integrationRoiGroup` we can associate the 368 ROIs with the plane they belong to from `"zs": 0/30/55` 
+
+--> in `targeted_list` the ROI are ordered as the one reported in `integrationRoiGroup`?
+--> is Plane0 at zs = 0, Plane1 at zs = 30 and Plane2 at zs = 55 for Suite2p data?
+
+If so we can recover the extact roi_id pointing to the correct PlaneSegmentation where the roi are stored.
+
 1. <span style="color: red;">Where the Suite2p ROIs indces are saved?</span> 
 2. <span style="color: red;">How are they combined? Simply concatenated over the planes?</span> 
 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_notes.md
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023_notes.md
@@ -1,15 +1,20 @@
 # Notes concerning the abdeladim_2023 conversion
 
+
+# Reference papers
+From [Probing inter-areal computations with a cellular resolution two-photon holographic mesoscope](https://www.biorxiv.org/content/10.1101/2023.03.02.530875v2.full): 
+Holographic emulation of visually evoked neural activity at the mesoscale by specific co-activation of functionally defined ensembles (holograms). They further showed how one can use this system to probe functional interactions between distant brain regions. Finally, they showed that they can decode the identity of the specific photo-stimulus purely from the modulation of activity of postsynaptic neurons in downstream areas.
+
+See also [The logic of recurrent circuits in the primary visual cortex](https://www.biorxiv.org/content/10.1101/2022.09.20.508739v1.full)
+ and  [All-optical recreation of naturalistic neural activity with a multifunctional transgenic reporter mouse](https://www.sciencedirect.com/science/article/pii/S2211124723009208)
+
 ## Experimental protocol:
-TODO: update with other papers: 
-https://www.biorxiv.org/content/10.1101/2022.09.20.508739v1.full ,
-https://www.sciencedirect.com/science/article/pii/S2211124723009208
 
-From [Paper1](https://www.biorxiv.org/content/10.1101/2023.03.02.530875v2.full): Holographic emulation of visually evoked neural activity at the mesoscale by specific co-activation of functionally defined ensembles. We further showed how one can use this system to probe functional interactions between distant brain regions. Finally, we showed that we can decode the identity of the specific photo-stimulus purely from the modulation of activity of postsynaptic neurons in downstream areas.
-
-From [Paper2](https://www.biorxiv.org/content/10.1101/2022.09.20.508739v1.full):
-
-From [Paper3](https://www.sciencedirect.com/science/article/pii/S2211124723009208):
+The microscope is calibrated to aim holograms/optogenetic stimulation to pixel coordinates in ScanImage. 
+After motion correcting and processing the data with suite2p, they extract cell masks and traces. 
+Then (x,y) pixel targeted locations are matched to (x,y) suite2p locations using a simple distance matching algorithm (with a maximum distance threshold). 
+For various reasons, suite2p will not always detect a cell in the location where hologram shoul be. 
+To preserve indexing, those are marked as NaN.
 
 ## Data streams:
 
@@ -23,80 +28,93 @@ https://www.sciencedirect.com/science/article/pii/S2211124723009208
 - Holographic stimulation (Custom Matlab code, HDF5 file)
 - event annotations. missing
 
-**From [Paper1](https://www.biorxiv.org/content/10.1101/2023.03.02.530875v2.full):**
-- imaging data (Scan Image),
-- segmentation (Suite2P), 
-- Holographic stimulation 
-- Visual stimulation
-- retinotopy
-(Custom Matlab code was used for control of the photostimulation path hardware, synchronization with imaging and control of the visual stimulation)
-
-**From [Paper2](https://www.biorxiv.org/content/10.1101/2022.09.20.508739v1.full):**
-
-**From [Paper3](https://www.sciencedirect.com/science/article/pii/S2211124723009208):**
-
 ### Data exploraton:
+The example data shared is structured as follow:
+- imaging data --> "raw_tiffs" folder containing a folder for each session: "2ret","3ori","4ori","5stim","6stim","7expt"
+- suite2p data --> "processed-suite2p-data"
+- holographic stimulation -->  processed "example_data.hdf5" file
+
 #### Imaging data (ScanImage):
+- each session has multiple .tif files to be concatenated in time --> use MultiImageExtractor
+- image dimension: 
+    - n_xpixels: `'SI.hRoiManager.pixelsPerLine': '512'`
+    - n_ypixels: `'SI.hRoiManager.linesPerFrame': '512'`
+- number of planes:   `'SI.hStackManager.numSlices': '3'`
+- ? is it the distances at which the 3 planes are acquired: `'SI.hStackManager.arbitraryZs': '[0 30 55]',`. If it's so this represent the voxel number at which the planes are acquired. Infact if we look at names of the three .tiff files common to all sessions (`img800`,`img920`,`img1020` which probably indicates summary images at the 3 different planes) we can extract the info that:
+    - Plane0 is acquired at 800um 
+    - Plane1 is acquired at 920um (with a relative ditance from Plane0 of 30*4um)
+    - Plane2 is acquired at 1020um (with a relative ditance from Plane0 of 55*4um)
+From this I suppose that the grid_spacing in the z direction is 4um but I need to confirm
+- two channel: "Channel 1"--> Green, "Channel 2" --> Red 
+    - `SI.hChannels.channelMergeColor : {'green';'red';'red';'red'}`
+    - `SI.hChannels.channelName : {'Channel 1' 'Channel 2' 'Channel 3' 'Channel 4'}`
+    - `SI.hChannels.channelSave : [1;2]`
+- round-robin acquisition at --> `SI.hRoiManager.scanFrameRate: 19.0686`
+- plane acquisition rate at --> `SI.hRoiManager.scanVolumeRate : 6.35621`
+- line acquisition rate at -->  1/`SI.hRoiManager.linePeriod : 6.31833e-05`
 
-**General checks**
+- ? is this the subject_id? `'SI.hUserFunctions.userFunctionsCfg__8.Arguments': "{'w51_1'}"`
 
--[x] Each tif. file in the session folder hase the same starting session datetime and sampling frequency
--[x] Regular sampling frequency over the timestamps extracted from all files in the session folder. NB: extract timestamp as in line 164-166 scanimagetiddimagingextractor.py --> **No regular sampling frequency** 
-In particular, some of the .tif file have regular timestamps (round robin 19.0686 Hz, circa 6.35 Hz per slice), some not.
---> save timestamps not sampling frequency? (option not implemented in Scan Image interface/extractor)
---> the sampling frequency currently extracted in scan image extratctor is referred to the round robin frequency not the one of single channel acquisition
---> does the extractor account for dropped frames? 
--------------------------------------
-**FOLLOWING: is all taken care by ScanImage interface and extractor**
-- imaging data (ScanImage): 
-    - shape of image on a single tif (open with tifffile): n_volumes:96, n_channels:2, n_xpixels:512, n_ypixels:512 (sometimes 93 not 96). 
-    NB: From [ScanImage](https://docs.scanimage.org/Concepts/Volume+Imaging.html?highlight=frames+per+volume) doc
-        >Number of Volumes: This indicates the number of times, if any, that the  stack, or single volume, should be repetitively acquired.
-    - shape of image on a single tif (open with ScanImageTiffReader): (n_channels x n_planes x n_repetition):192, n_xpixels:512, n_ypixels:512
-    where can we get *n_repetition*?
-        From [analysis code](https://github.com/willyh101/analysis/blob/5bd562ca531a6cc9ce9a57ed76229d89a8fcb82d/holofun/si_tiff.py#L157C1-L170C68), the way we slice the data in the tif: 
-        ```
-        slice((z_idx*nchannels)+ch_idx, None, nplanes*nchannels) 
-        ```
-        This means that its a stack of frames that should be acquired as follow:
-        1. plane0, Channel 1/green
-        2. plane0, Channel 2/red
-        3. plane1, Channel 1/green
-        4. plane1, Channel 2/red
-        5. plane2, Channel 1/green
-        6. plane2, Channel 2/red 
-        ...repeat       
-    - from metadata extracted with `extract_extra_metadata` function 
-        - SI.hChannels.channelMergeColor : {'green';'red';'red';'red'}
-        - SI.hChannels.channelName : {'Channel 1' 'Channel 2' 'Channel 3' 'Channel 4'}
-        - SI.hChannels.channelOffset : [-6314 -855 -90 -249]
-        - SI.hChannels.channelSave : [1;2]
-        - SI.hStackManager.actualNumSlices : 3
-        - SI.hStackManager.actualNumVolumes : 100
-        - SI.hStackManager.actualStackZStepSize : 30
-        - SI.hStackManager.framesPerSlice : 1
+**Other metadata needed for the imaging data stream:**
+- grid_spacing in um for x, y and z direction 
+- indicators for the 2 optical channels
+- emission_lambda for the 2 optical channels
+- excitation_lambda taken from paper: 920 nm 
 ---------------------------
+#### Segmentation data (Suite2P),
+The output of suit2p are not divided into sessions and there is no reference about the session to which it refers to. Thus, I checked the nuber of frames for the s2p data to see if I found any corrispondence with the one of the session, but turns out that:
+- Suit2p data has 41305 frames for each Plane
+- While raw imaing data has in total 31422 frames (for each channel and plane combo):
+    - 9604 in session 2ret
+    - 6203 in session 3ori
+    - 6394 in session 4ori
+    - 1708 in session 5stim
+    - 3527 in session 6stim
+    - 3986 in session 7expt
+
+Then I notice that the subject_id is different:
+    - 'w57_1' from paths saved in suite2p (and 'frames_per_folder': [ 9604,  6203,  6394,  1708,  3527, 13869]),
+    - 'w51_1' from ScanImage userFunction
+
+Therefore, the Suit2p processing is done by concatenating the different sessions/epochs. 
+--> we should save timestamps for the suit2p data as well as for the imaging series
+--> we could save each epoch as a separate series, so that the series' description can be specific of the protocol and the holographic series that refers to just "5stim" and  "7expt" has a direct correspective in the acquisition imaging series.
+
+---------------------------
+#### Holographic stimulation data (custom):
+The holographic data are just for the the "5stim" and "7expt" sessions
+from the README provided in the data folder:
+**Variables and nomenclature**
+`roi` = suite2p cell or roi. integer index into suite2p rois. NaN is a placeholder for a location that was targeted but not detected by suite2p. <span style="color: red;">missing</span>
+`hologram` = array/list of targeted rois that comprise a single stimulation event. i.e. a hologram could be a single cell stimulated, or n cells stimulated simultaneously. <span style="color: red;">missing</span>
+`hologram_list` = list of unique stimulations/holograms that is indexed by `stim_id`
+`targeted_cells` = overally list of all suite2p cells targeted and matched to holographic stimuli
+`stim_times` = stimulation time (in seconds) within a trial for each roi, NaN means the cell was not stimulated
+`stim_id` = trialwise index into `hologram_list`, note this is idx-1, as the first "stim" condition is a control trial
+`power_per_cell` = power per cell/stimulation site in mW
+`spikes_per_cell` = stim frequency per cell/stimulation site <span style="color: red;">what is the difference from hz_per_cell?</span>.
+`hz_per_cell` = stimulationd frequency per cell/stimulation site
+`frame_rate` = aquisition frame rate in Hz <span style="color: red;">missing</span>.
+
+##### Session "5stim"
+In "5stim" there are 24 trials (`len(stim_id): 24`) and 36 combinations of max 10 ROIs (over a total of 368-->`len(targeted_cells)`) stimulated at the same time (`hologram_list.shape: (36,10)`). Only the first 8 combinations are referred in `stim_id`, the actual values of `stim_id` range from 0 (that is a control trial where there is no actual stimulation: `power_per_cell` and `spikes_per_cell` are 0) to 8 (`hologram_list[7]`).
+
+##### Session "7expt"
+In "7expt" there are 723 trials (`len(stim_id): 723`) and 10 ROIs stimulated in separate trials alone (`hologram_list.shape: (10,1)`). All ROIs in hologram list are stimulated at least once: `stim_id` range from 0 -control trial- to 10 (`hologram_list[9]`).
+NB: for `stim_id`=4 --> `hologram_list[3]` is nan <span style="color: red;">why?</span> 
+
+**<span style="color: red;">Problem:</span>** `stim_times` it's relative to each trial but we don't know when each trials starts with respect to the starting time of the session. We need to know the actual timestamps in order to align with the other data stream
 
 
-- segmentation (Suite2P), #TODO
-## Data organisation: 
-- Raw tiff: 7 experimental session:
-    - ret (retinotopy)
-    - ori (orientation)
-    - stim (holographic stimulus or visual stimulus?)
-    - expt (?)
 --------------------
 **Ignore these files**
-For each epochs we have:
-- `\*IntegrationRois\*.csv` which headers are: [`timestamp`, `frameNumber`, `ROI 1`, `ROI 2`, `ROI 3`, etc]. 
-- `\*PSTH\*.mat`.
-- makeMasks3D_img.mat : image masks for identified ROIs (red and green channel superimpose - blue channel is 0) and target ROIs for photstim (3 distinct axial `slices` that are acquired round-robin at ~19Hz total (~6Hz / slice)
+- makeMasks3D_img.mat : image masks for identified ROIs (red and green channel superimpose - blue channel is 0) and target ROIs for photstim (3 distinct axial `slices` that are acquired round-robin at ~19Hz total (~6Hz / slice))
 - `img920`: tiff_path.rglob(`\*920_\*.tif\*`),
 - `img1020`: tiff_path.rglob(`\*1020_\*.tif\*`),
 - `img800`: tiff_path.rglob(`\*800_\*.tif\*`),
-I assume they are summary images for the 3 slices and 800/920/1020 has something to do with the spatial information.
 
-However, from the analysis code, I can see there are other files that potentially contain critical metadata:
+## Metadata:
+From the analysis code, I can see there are other files that potentially contain critical metadata:
 - <span style="color: red;">`setupdaq`: tiff_path.glob(date[2:]+`\*.mat`)</span>,
 - `s2p`: edrive.rglob(`suite2p`),
 - `clicked_cells`: tiff_path.rglob(`\*clicked\*.npy`),
@@ -108,13 +126,26 @@ However, from the analysis code, I can see there are other files that potentiall
 - <span style="color: red;">`ret`: tiff_path.rglob(`\*ret\*.mat`)</span>,
 `si_online`: tiff_path.rglob(`\*IntegrationRois\*.csv`),
 - <span style="color: red;">`mat`: tiff_path.rglob(`\*.mat`)</span>
---------------------
 
-Always in the analysis code, in particular in the [SetupDaqFile](https://github.com/willyh101/analysis/blob/5bd562ca531a6cc9ce9a57ed76229d89a8fcb82d/holofun/daq.py#L11C1-L58C59) class there is a reference to a dataset containing even subject metadata. 
-## Metadata:
+In the analysis code, in particular in the [SetupDaqFile](https://github.com/willyh101/analysis/blob/5bd562ca531a6cc9ce9a57ed76229d89a8fcb82d/holofun/daq.py#L11C1-L58C59) class there is a reference to a dataset containing subject metadata. 
+
 From SetupDaqFile class in holofun, I see there is a lot of metadata that must go into the NWBFile. They seem to come from a .mat file called setupdaq
 > HDF5 file and Suite2P files has all info needed.  
 ## Lab code:
 [willyh101/analysis](https://github.com/willyh101/analysis/tree/5bd562ca531a6cc9ce9a57ed76229d89a8fcb82d)
 [adesnik-lab/holography](https://github.com/adesnik-lab/holography/tree/main)
+
+
+# <span style="color: red;">Questions:</span>
+
+**<span style="color: red;">1. Other metadata needed for the imaging data stream:</span>**
+- grid_spacing in um for x, y and z direction 
+- indicators for the 2 optical channels
+- emission_lambda for the 2 optical channels
+- excitation_lambda taken from paper: 920 nm 
+**<span style="color: red;">2. Should we save the ImageSeries as a volumetric data or as a separate planes?</span>**
+**<span style="color: red;">3. Should we concatenate the 6 epochs in one ImageSeries, or should we keep them separate?</span>**
+**<span style="color: red;">4. We need info on the subject</span>**
+**<span style="color: red;">5. We need info on the session</span>**
+
 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -3,19 +3,22 @@ from pathlib import Path
 import glob
 from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextractor import (
     ScanImageTiffMultiPlaneImagingExtractor,
+    ScanImageTiffSinglePlaneImagingExtractor,
 )
 from roiextractors.extractors.tiffimagingextractors.brukertiffimagingextractor import (
     BrukerTiffMultiPlaneImagingExtractor,
 )
 from roiextractors.imagingextractor import ImagingExtractor
+from roiextractors.multiimagingextractor import MultiImagingExtractor
+
 from roiextractors.extraction_tools import PathType, FloatType, ArrayType, DtypeType, get_package
 import numpy as np
 
 
-class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
+class Abdeladim2023MultiPlaneImagingExtractor(ImagingExtractor):
     """Specialized extractor for Abdeladim2023 conversion project: reading ScanImage .tif files chunked over time"""
 
-    extractor_name = "Abdeladim2023VolumetricImagingExtractor"
+    extractor_name = "Abdeladim2023MultiPlaneImagingExtractor"
     is_writable = True
     mode = "folder"
 
@@ -28,10 +31,12 @@ class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
         tif_file_paths = sorted(glob.glob(f"{self.folder_path}/*.tif"))
         assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
 
-        self.imaging_extractors = [
+        imaging_extractors = [
             ScanImageTiffMultiPlaneImagingExtractor(file_path=file_path, channel_name=channel_name)
             for file_path in tif_file_paths
         ]
+
+        self.imaging_extractor = MultiImagingExtractor(imaging_extractors)
 
     def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
         """Get specific video frames from indices (not necessarily continuous).
@@ -46,32 +51,10 @@ class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
         frames: numpy.ndarray
             The video frames.
         """
-        if isinstance(frame_idxs, int):
-            frame_idxs = [frame_idxs]
-
-        if not all(np.diff(frame_idxs) == 1):
-            return np.concatenate([self._get_single_frame(frame=idx) for idx in frame_idxs])
-        else:
-            return self.get_video(start_frame=frame_idxs[0], end_frame=frame_idxs[-1] + 1)
+        return self.imaging_extractor.get_frames(frame_idxs=frame_idxs)
 
     def get_num_frames(self) -> int:
-        return sum([extractor.get_num_frames() for extractor in self.imaging_extractors])
-
-    def _get_single_frame(self, frame: int) -> np.ndarray:
-        """Get a single frame of data from the TIFF file.
-
-        Parameters
-        ----------
-        frame : int
-            The index of the frame to retrieve.
-
-        Returns
-        -------
-        frame: numpy.ndarray
-            The frame of data.
-        """
-
-        return self.get_video(start_frame=frame, end_frame=frame + 1)
+        return self.imaging_extractor.get_num_frames()
 
     def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None) -> np.ndarray:
         """Get the video frames.
@@ -88,22 +71,90 @@ class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
         video: numpy.ndarray
             The video frames.
         """
-        start = start_frame if start_frame is not None else 0
-        end = end_frame if end_frame is not None else self.get_num_frames()
-        video = []
-        for extractor in self.imaging_extractors:
-            video = np.append(video, extractor.get_video())
-
-        return video[:, :, :, start:end]
+        return self.imaging_extractor.get_video(start_frame=start_frame, end_frame=end_frame)
 
     def get_channel_names(self):
-        return self.imaging_extractors[0].get_channel_names()
+        return self.imaging_extractor.get_channel_names()
 
     def get_image_size(self):
-        return self.imaging_extractors[0].get_image_size()
+        return self.imaging_extractor.get_image_size()
 
     def get_num_channels(self):
-        return self.imaging_extractors[0].get_num_channels()
+        return self.imaging_extractor.get_num_channels()
 
     def get_sampling_frequency(self):
-        return self.imaging_extractors[0].get_sampling_frequency()
+        return self.imaging_extractor.get_sampling_frequency()
+
+
+class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
+    """Specialized extractor for Abdeladim2023 conversion project: reading ScanImage .tif files chunked over time"""
+
+    extractor_name = "Abdeladim2023SinglePlaneImagingExtractor"
+    is_writable = True
+    mode = "folder"
+
+    def __init__(
+        self,
+        folder_path: PathType,
+        channel_name: str,
+        plane_name: str,
+    ) -> None:
+        self.folder_path = Path(folder_path)
+        tif_file_paths = sorted(glob.glob(f"{self.folder_path}/*.tif"))
+        assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
+
+        imaging_extractors = [
+            ScanImageTiffSinglePlaneImagingExtractor(
+                file_path=file_path, channel_name=channel_name, plane_name=plane_name
+            )
+            for file_path in tif_file_paths
+        ]
+
+        self.imaging_extractor = MultiImagingExtractor(imaging_extractors)
+
+    def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
+        """Get specific video frames from indices (not necessarily continuous).
+
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        return self.imaging_extractor.get_frames(frame_idxs=frame_idxs)
+
+    def get_num_frames(self) -> int:
+        return self.imaging_extractor.get_num_frames()
+
+    def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        return self.imaging_extractor.get_video(start_frame=start_frame, end_frame=end_frame)
+
+    def get_channel_names(self):
+        return self.imaging_extractor.get_channel_names()
+
+    def get_image_size(self):
+        return self.imaging_extractor.get_image_size()
+
+    def get_num_channels(self):
+        return self.imaging_extractor.get_num_channels()
+
+    def get_sampling_frequency(self):
+        return self.imaging_extractor.get_sampling_frequency()

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -5,9 +5,7 @@ from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextracto
     ScanImageTiffMultiPlaneImagingExtractor,
     ScanImageTiffSinglePlaneImagingExtractor,
 )
-from roiextractors.extractors.tiffimagingextractors.brukertiffimagingextractor import (
-    BrukerTiffMultiPlaneImagingExtractor,
-)
+
 from roiextractors.imagingextractor import ImagingExtractor
 from roiextractors.multiimagingextractor import MultiImagingExtractor
 
@@ -37,6 +35,8 @@ class Abdeladim2023MultiPlaneImagingExtractor(ImagingExtractor):
         ]
 
         self.imaging_extractor = MultiImagingExtractor(imaging_extractors)
+        times = self.imaging_extractor._get_times()
+        self.set_times(times=times)
 
     def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
         """Get specific video frames from indices (not necessarily continuous).
@@ -111,6 +111,8 @@ class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
         ]
 
         self.imaging_extractor = MultiImagingExtractor(imaging_extractors)
+        times = self.imaging_extractor._get_times()
+        self.set_times(times=times)
 
     def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
         """Get specific video frames from indices (not necessarily continuous).

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -1,6 +1,5 @@
 from typing import Optional, Tuple, List, Iterable
 from pathlib import Path
-import glob
 from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextractor import (
     ScanImageTiffMultiPlaneImagingExtractor,
     ScanImageTiffSinglePlaneImagingExtractor,
@@ -11,6 +10,7 @@ from roiextractors.multiimagingextractor import MultiImagingExtractor
 
 from roiextractors.extraction_tools import PathType, FloatType, ArrayType, DtypeType, get_package
 import numpy as np
+from natsort import natsorted
 
 
 class Abdeladim2023MultiPlaneImagingExtractor(MultiImagingExtractor):
@@ -26,8 +26,8 @@ class Abdeladim2023MultiPlaneImagingExtractor(MultiImagingExtractor):
         channel_name: Optional[str] = None,
     ) -> None:
         self.folder_path = Path(folder_path)
-        tif_file_paths = sorted(glob.glob(f"{self.folder_path}/*.tif"))
-        assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
+        tif_file_paths = natsorted(self.folder_path.glob("*.tif"))
+        assert tif_file_paths, f"The TIF image files are missing from '{self.folder_path}'."
 
         imaging_extractors = [
             ScanImageTiffMultiPlaneImagingExtractor(file_path=file_path, channel_name=channel_name)
@@ -37,7 +37,7 @@ class Abdeladim2023MultiPlaneImagingExtractor(MultiImagingExtractor):
         super().__init__(imaging_extractors=imaging_extractors)
 
 
-class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
+class Abdeladim2023SinglePlaneImagingExtractor(MultiImagingExtractor):
     """Specialized extractor for Abdeladim2023 conversion project: reading ScanImage .tif files chunked over time"""
 
     extractor_name = "Abdeladim2023SinglePlaneImagingExtractor"
@@ -51,7 +51,7 @@ class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
         plane_name: str,
     ) -> None:
         self.folder_path = Path(folder_path)
-        tif_file_paths = sorted(glob.glob(f"{self.folder_path}/*.tif"))
+        tif_file_paths = natsorted(self.folder_path.glob("*.tif"))
         assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
 
         imaging_extractors = [
@@ -61,53 +61,5 @@ class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
             for file_path in tif_file_paths
         ]
 
-        self.imaging_extractor = MultiImagingExtractor(imaging_extractors)
-        times = self.imaging_extractor._get_times()
-        self.set_times(times=times)
+        super().__init__(imaging_extractors=imaging_extractors)
 
-    def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
-        """Get specific video frames from indices (not necessarily continuous).
-
-        Parameters
-        ----------
-        frame_idxs: array-like
-            Indices of frames to return.
-
-        Returns
-        -------
-        frames: numpy.ndarray
-            The video frames.
-        """
-        return self.imaging_extractor.get_frames(frame_idxs=frame_idxs)
-
-    def get_num_frames(self) -> int:
-        return self.imaging_extractor.get_num_frames()
-
-    def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None) -> np.ndarray:
-        """Get the video frames.
-
-        Parameters
-        ----------
-        start_frame: int, optional
-            Start frame index (inclusive).
-        end_frame: int, optional
-            End frame index (exclusive).
-
-        Returns
-        -------
-        video: numpy.ndarray
-            The video frames.
-        """
-        return self.imaging_extractor.get_video(start_frame=start_frame, end_frame=end_frame)
-
-    def get_channel_names(self):
-        return self.imaging_extractor.get_channel_names()
-
-    def get_image_size(self):
-        return self.imaging_extractor.get_image_size()
-
-    def get_num_channels(self):
-        return self.imaging_extractor.get_num_channels()
-
-    def get_sampling_frequency(self):
-        return self.imaging_extractor.get_sampling_frequency()

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple, List, Iterable
 from pathlib import Path
-import glob
+from natsort import natsorted
 from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextractor import (
     ScanImageTiffMultiPlaneImagingExtractor,
     ScanImageTiffSinglePlaneImagingExtractor,
@@ -26,7 +26,7 @@ class Abdeladim2023MultiPlaneImagingExtractor(ImagingExtractor):
         channel_name: Optional[str] = None,
     ) -> None:
         self.folder_path = Path(folder_path)
-        tif_file_paths = sorted(glob.glob(f"{self.folder_path}/*.tif"))
+        tif_file_paths = natsorted(self.folder_path.glob("*.tif"))
         assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
 
         imaging_extractors = [
@@ -100,7 +100,7 @@ class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
         plane_name: str,
     ) -> None:
         self.folder_path = Path(folder_path)
-        tif_file_paths = sorted(glob.glob(f"{self.folder_path}/*.tif"))
+        tif_file_paths = natsorted(self.folder_path.glob("*.tif"))
         assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
 
         imaging_extractors = [

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -33,8 +33,6 @@ class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
             for file_path in tif_file_paths
         ]
 
-        self._num_frames = sum([extractor.get_num_frames() for extractor in self.imaging_extractors])
-
     def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
         """Get specific video frames from indices (not necessarily continuous).
 
@@ -57,7 +55,7 @@ class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
             return self.get_video(start_frame=frame_idxs[0], end_frame=frame_idxs[-1] + 1)
 
     def get_num_frames(self) -> int:
-        return self._num_frames
+        return sum([extractor.get_num_frames() for extractor in self.imaging_extractors])
 
     def _get_single_frame(self, frame: int) -> np.ndarray:
         """Get a single frame of data from the TIFF file.
@@ -97,10 +95,10 @@ class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
             video = np.append(video, extractor.get_video())
 
         return video[:, :, :, start:end]
-    
+
     def get_channel_names(self):
         return self.imaging_extractors[0].get_channel_names()
-    
+
     def get_image_size(self):
         return self.imaging_extractors[0].get_image_size()
 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -1,0 +1,111 @@
+from typing import Optional, Tuple, List, Iterable
+from pathlib import Path
+import glob
+from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextractor import (
+    ScanImageTiffMultiPlaneImagingExtractor,
+)
+from roiextractors.extractors.tiffimagingextractors.brukertiffimagingextractor import (
+    BrukerTiffMultiPlaneImagingExtractor,
+)
+from roiextractors.imagingextractor import ImagingExtractor
+from roiextractors.extraction_tools import PathType, FloatType, ArrayType, DtypeType, get_package
+import numpy as np
+
+
+class Abdeladim2023VolumetricImagingExtractor(ImagingExtractor):
+    """Specialized extractor for Abdeladim2023 conversion project: reading ScanImage .tif files chunked over time"""
+
+    extractor_name = "Abdeladim2023VolumetricImagingExtractor"
+    is_writable = True
+    mode = "folder"
+
+    def __init__(
+        self,
+        folder_path: PathType,
+        channel_name: Optional[str] = None,
+    ) -> None:
+        self.folder_path = Path(folder_path)
+        tif_file_paths = sorted(glob.glob(f"{self.folder_path}/*.tif"))
+        assert tif_file_paths, f"The TIF image files are missing from '{folder_path}'."
+
+        self.imaging_extractors = [
+            ScanImageTiffMultiPlaneImagingExtractor(file_path=file_path, channel_name=channel_name)
+            for file_path in tif_file_paths
+        ]
+
+        self._num_frames = sum([extractor.get_num_frames() for extractor in self.imaging_extractors])
+
+    def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
+        """Get specific video frames from indices (not necessarily continuous).
+
+        Parameters
+        ----------
+        frame_idxs: array-like
+            Indices of frames to return.
+
+        Returns
+        -------
+        frames: numpy.ndarray
+            The video frames.
+        """
+        if isinstance(frame_idxs, int):
+            frame_idxs = [frame_idxs]
+
+        if not all(np.diff(frame_idxs) == 1):
+            return np.concatenate([self._get_single_frame(frame=idx) for idx in frame_idxs])
+        else:
+            return self.get_video(start_frame=frame_idxs[0], end_frame=frame_idxs[-1] + 1)
+
+    def get_num_frames(self) -> int:
+        return self._num_frames
+
+    def _get_single_frame(self, frame: int) -> np.ndarray:
+        """Get a single frame of data from the TIFF file.
+
+        Parameters
+        ----------
+        frame : int
+            The index of the frame to retrieve.
+
+        Returns
+        -------
+        frame: numpy.ndarray
+            The frame of data.
+        """
+
+        return self.get_video(start_frame=frame, end_frame=frame + 1)
+
+    def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None) -> np.ndarray:
+        """Get the video frames.
+
+        Parameters
+        ----------
+        start_frame: int, optional
+            Start frame index (inclusive).
+        end_frame: int, optional
+            End frame index (exclusive).
+
+        Returns
+        -------
+        video: numpy.ndarray
+            The video frames.
+        """
+        start = start_frame if start_frame is not None else 0
+        end = end_frame if end_frame is not None else self.get_num_frames()
+        video = []
+        for extractor in self.imaging_extractors:
+            video = np.append(video, extractor.get_video())
+
+        return video[:, :, :, start:end]
+    
+    def get_channel_names(self):
+        return self.imaging_extractors[0].get_channel_names()
+    
+    def get_image_size(self):
+        return self.imaging_extractors[0].get_image_size()
+
+    def get_num_channels(self):
+        return self.imaging_extractors[0].get_num_channels()
+
+    def get_sampling_frequency(self):
+        return self.imaging_extractors[0].get_sampling_frequency()

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -8,7 +8,7 @@ from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextracto
 
 from roiextractors.imagingextractor import ImagingExtractor
 from roiextractors.multiimagingextractor import MultiImagingExtractor
-
+from neuroconv.utils import FolderPathType
 from roiextractors.extraction_tools import PathType, FloatType, ArrayType, DtypeType, get_package
 import numpy as np
 
@@ -22,7 +22,7 @@ class Abdeladim2023MultiPlaneImagingExtractor(ImagingExtractor):
 
     def __init__(
         self,
-        folder_path: PathType,
+        folder_path: FolderPathType,
         channel_name: Optional[str] = None,
     ) -> None:
         self.folder_path = Path(folder_path)
@@ -95,7 +95,7 @@ class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
 
     def __init__(
         self,
-        folder_path: PathType,
+        folder_path: FolderPathType,
         channel_name: str,
         plane_name: str,
     ) -> None:
@@ -114,7 +114,7 @@ class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
         times = self.imaging_extractor._get_times()
         self.set_times(times=times)
 
-    def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
+    def get_frames(self, frame_idxs: ArrayType,channel: Optional[int] = 0) -> np.ndarray:
         """Get specific video frames from indices (not necessarily continuous).
 
         Parameters
@@ -132,7 +132,7 @@ class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):
     def get_num_frames(self) -> int:
         return self.imaging_extractor.get_num_frames()
 
-    def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None) -> np.ndarray:
+    def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None,channel: Optional[int] = 0) -> np.ndarray:
         """Get the video frames.
 
         Parameters

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -5,8 +5,6 @@ from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextracto
     ScanImageTiffMultiPlaneImagingExtractor,
     ScanImageTiffSinglePlaneImagingExtractor,
 )
-
-from roiextractors.imagingextractor import ImagingExtractor
 from roiextractors.multiimagingextractor import MultiImagingExtractor
 from neuroconv.utils import FolderPathType
 from roiextractors.extraction_tools import PathType, FloatType, ArrayType, DtypeType, get_package

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imagingextractor.py
@@ -13,7 +13,7 @@ from roiextractors.extraction_tools import PathType, FloatType, ArrayType, Dtype
 import numpy as np
 
 
-class Abdeladim2023MultiPlaneImagingExtractor(ImagingExtractor):
+class Abdeladim2023MultiPlaneImagingExtractor(MultiImagingExtractor):
     """Specialized extractor for Abdeladim2023 conversion project: reading ScanImage .tif files chunked over time"""
 
     extractor_name = "Abdeladim2023MultiPlaneImagingExtractor"
@@ -34,56 +34,7 @@ class Abdeladim2023MultiPlaneImagingExtractor(ImagingExtractor):
             for file_path in tif_file_paths
         ]
 
-        self.imaging_extractor = MultiImagingExtractor(imaging_extractors)
-        times = self.imaging_extractor._get_times()
-        self.set_times(times=times)
-
-    def get_frames(self, frame_idxs: ArrayType) -> np.ndarray:
-        """Get specific video frames from indices (not necessarily continuous).
-
-        Parameters
-        ----------
-        frame_idxs: array-like
-            Indices of frames to return.
-
-        Returns
-        -------
-        frames: numpy.ndarray
-            The video frames.
-        """
-        return self.imaging_extractor.get_frames(frame_idxs=frame_idxs)
-
-    def get_num_frames(self) -> int:
-        return self.imaging_extractor.get_num_frames()
-
-    def get_video(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None) -> np.ndarray:
-        """Get the video frames.
-
-        Parameters
-        ----------
-        start_frame: int, optional
-            Start frame index (inclusive).
-        end_frame: int, optional
-            End frame index (exclusive).
-
-        Returns
-        -------
-        video: numpy.ndarray
-            The video frames.
-        """
-        return self.imaging_extractor.get_video(start_frame=start_frame, end_frame=end_frame)
-
-    def get_channel_names(self):
-        return self.imaging_extractor.get_channel_names()
-
-    def get_image_size(self):
-        return self.imaging_extractor.get_image_size()
-
-    def get_num_channels(self):
-        return self.imaging_extractor.get_num_channels()
-
-    def get_sampling_frequency(self):
-        return self.imaging_extractor.get_sampling_frequency()
+        super().__init__(imaging_extractors=imaging_extractors)
 
 
 class Abdeladim2023SinglePlaneImagingExtractor(ImagingExtractor):

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -3,7 +3,7 @@ import datetime
 import json
 from pathlib import Path
 from natsort import natsorted
-from .abdeladim_2023imagingextractor import (
+from abdeladim_2023imagingextractor import (
     Abdeladim2023MultiPlaneImagingExtractor,
     Abdeladim2023SinglePlaneImagingExtractor,
 )
@@ -74,12 +74,12 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
         channel_metadata = {
             "Channel1": {
                 "name": "Green",
-                #"emission_lambda": 513.0, # Not specified
+                "emission_lambda": 513.0, # Not specified
                 "description": "Green channel of the microscope",
             },
             "Channel2": {
                 "name": "Red",
-                #"emission_lambda": 581.0,# Not specified
+                "emission_lambda": 581.0,# Not specified
                 "description": "Red channel of the microscope",
             },
         }[channel_name_without_space]
@@ -112,17 +112,7 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
             scan_line_rate=1 / float(self.image_metadata["SI.hRoiManager.linePeriod"]),
             rate=self.imaging_extractor.get_sampling_frequency(),
             description=f"Two photon series acquired with {self.channel_name} at plane {self.plane_name}",
-            # unit="n.a.",
-            # dimension=self.imaging_extractor.get_image_size(),
         )
 
         return metadata
 
-    two_photon_series_index = {
-        "TwoPhotonSeriesChannel1Plane0": 0,
-        "TwoPhotonSeriesChannel1Plane1": 1,
-        "TwoPhotonSeriesChannel1Plane2": 2,
-        "TwoPhotonSeriesChannel2Plane0": 3,
-        "TwoPhotonSeriesChannel2Plane1": 4,
-        "TwoPhotonSeriesChannel2Plane2": 5,
-    }

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -1,0 +1,112 @@
+from dateutil.parser import parse as dateparse
+import datetime
+import json
+import glob
+
+from abdeladim_2023imagingextractor import (
+    Abdeladim2023MultiPlaneImagingExtractor,
+    Abdeladim2023SinglePlaneImagingExtractor,
+)
+from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
+from neuroconv.utils import FolderPathType
+from neuroconv.utils.dict import DeepDict
+from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import extract_extra_metadata
+
+class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
+    """
+    Data Interface for writing imaging data for the MouseV1 to NWB file using Abdeladim2023SinglePlaneImagingExtractor.
+    """
+
+    Extractor = Abdeladim2023SinglePlaneImagingExtractor
+
+    def __init__(
+        self,
+        folder_path: FolderPathType,
+        channel_name: str,
+        plane_name: str,
+        verbose: bool = True,
+    ):
+        self.channel_name = channel_name
+        self.plane_name = plane_name
+
+        file_path = sorted(glob.glob(f"{folder_path}/*.tif"))
+        self.image_metadata = extract_extra_metadata(file_path=file_path[0])
+        super().__init__(folder_path=folder_path,channel_name=channel_name,plane_name=plane_name, verbose=verbose)
+
+    def get_metadata(self) -> DeepDict:
+        device_number = 0  # Imaging plane metadata is a list with metadata for each plane
+        metadata = super().get_metadata()
+        if "state.internal.triggerTimeString" in self.image_metadata:
+            extracted_session_start_time = dateparse(self.image_metadata["state.internal.triggerTimeString"])
+            metadata["NWBFile"].update(session_start_time=extracted_session_start_time)
+        elif "epoch" in self.image_metadata:
+            # Versions of ScanImage at least as recent as 2020, and possibly earlier, store the start time under keyword
+            # `epoch`, as a string encoding of a Matlab array, example `'[2022  8  8 16 56 7.329]'`
+            # dateparse can't cope with this representation, so using strptime directly
+            extracted_session_start_time = datetime.datetime.strptime(
+                self.image_metadata["epoch"], "[%Y %m %d %H %M %S.%f]"
+            )
+            metadata["NWBFile"].update(session_start_time=extracted_session_start_time)
+
+        # Extract many scan image properties and attach them as dic in the description
+        ophys_metadata = metadata["Ophys"]
+        two_photon_series_metadata = ophys_metadata["TwoPhotonSeries"][device_number]
+        if self.image_metadata is not None:
+            extracted_description = json.dumps(self.image_metadata)
+            two_photon_series_metadata.update(description=extracted_description)
+        channel_name_without_space = self.channel_name.replace(" ","")
+        indicators = {"Channel1":"GCaMP6f", "Channel2":"tdTomato"}
+
+        channel_metadata = {
+            "Channel1": {
+                "name": "Green",
+                "emission_lambda": 513.0, #TODO check
+                "description": "Green channel of the microscope, 525/50 nm filter.",#TODO check
+            },
+            "Channel2": {
+                "name": "Red",
+                "emission_lambda": 581.0,#TODO check
+                "description": "Red channel of the microscope, 550/50 nm filter.",#TODO check
+            },
+        }[channel_name_without_space]
+
+        optical_channel_metadata = channel_metadata
+
+        device_name = "ADD_DEVICE_NAME" #TODO add device name
+        metadata["Ophys"]["Device"][0].update(
+            name=device_name, description="ADD_DEVICE_DESCRIPTION", manufacturer="ADD_DEVICE_MANUFACTURER" #TODO add device description and manufacturer
+        )
+
+        indicator = indicators[channel_name_without_space]
+        imaging_plane_name = f"ImagingPlane{channel_name_without_space}Plane{self.plane_name}"
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        imaging_plane_metadata.update(
+            name=imaging_plane_name,
+            optical_channel=[optical_channel_metadata],
+            device=device_name,
+            excitation_lambda=920.0, #TODO check
+            indicator=indicator,
+            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
+        )
+
+        two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
+        two_photon_series_metadata.update(
+            name=f"TwoPhotonSeries{channel_name_without_space}Plane{self.plane_name}",
+            imaging_plane=imaging_plane_name,
+            scan_line_rate=1/float(self.image_metadata['SI.hRoiManager.linePeriod']),
+            rate=self.imaging_extractor.get_sampling_frequency(),
+            description="ADD_2PSERIES_DESCRIPTION", #TODO ADD TwoPhotonSeries description
+            unit="px",
+            dimension = self.imaging_extractor.get_image_size()
+        )
+        
+        return metadata
+
+    two_photon_series_index = {
+        "TwoPhotonSeriesChannel1Plane0": 0,
+        "TwoPhotonSeriesChannel1Plane1": 1,
+        "TwoPhotonSeriesChannel1Plane2": 2,
+        "TwoPhotonSeriesChannel2Plane0": 3,        
+        "TwoPhotonSeriesChannel2Plane1": 4,
+        "TwoPhotonSeriesChannel2Plane2": 5,
+    }

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -2,7 +2,7 @@ from dateutil.parser import parse as dateparse
 import datetime
 import json
 import glob
-
+from natsort import natsorted
 from .abdeladim_2023imagingextractor import (
     Abdeladim2023MultiPlaneImagingExtractor,
     Abdeladim2023SinglePlaneImagingExtractor,
@@ -30,8 +30,8 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
         self.channel_name = channel_name
         self.plane_name = plane_name
 
-        file_path = sorted(glob.glob(f"{folder_path}/*.tif"))
-        self.image_metadata = extract_extra_metadata(file_path=file_path[0])
+        file_paths = natsorted(glob.glob(f"{folder_path}/*.tif"))
+        self.image_metadata = extract_extra_metadata(file_path=file_paths[0])
         super().__init__(folder_path=folder_path, channel_name=channel_name, plane_name=plane_name, verbose=verbose)
 
     def get_metadata(self) -> DeepDict:
@@ -99,7 +99,7 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
             scan_line_rate=1 / float(self.image_metadata["SI.hRoiManager.linePeriod"]),
             rate=self.imaging_extractor.get_sampling_frequency(),
             description=f"Two photon series acquired with {self.channel_name} at plane {self.plane_name}",
-            unit="px",
+            unit="n.a.",
             dimension=self.imaging_extractor.get_image_size(),
         )
 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -1,4 +1,5 @@
 from dateutil.parser import parse as dateparse
+from dateutil import tz
 import datetime
 import json
 from pathlib import Path
@@ -113,9 +114,7 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
             imaging_plane=imaging_plane_name,
             scan_line_rate=1 / float(self.image_metadata["SI.hRoiManager.linePeriod"]),
             description=f"Two photon series acquired with {self.channel_name} at plane {self.plane_name}",
+            rate=float(self.image_metadata["SI.hRoiManager.scanVolumeRate"]),
         )
 
         return metadata
-
-    def set_aligned_timestamps(self):
-        self.imaging_extractor._times

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -23,13 +23,13 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
 
     @classmethod
     def get_available_channels(cls, folder_path):
-        file_path = sorted(glob.glob(f"{folder_path}/*.tif"))
-        return ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=file_path[0])
+        tif_file_paths  = natsorted(folder_path.glob("*.tif"))
+        return ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=tif_file_paths[0])
 
     @classmethod
     def get_available_planes(cls, folder_path):
-        file_path = sorted(glob.glob(f"{folder_path}/*.tif"))
-        return ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=file_path[0]) 
+        tif_file_paths  = natsorted(folder_path.glob("*.tif"))
+        return ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=tif_file_paths[0]) 
 
     def __init__(
         self,
@@ -112,8 +112,8 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
             scan_line_rate=1 / float(self.image_metadata["SI.hRoiManager.linePeriod"]),
             rate=self.imaging_extractor.get_sampling_frequency(),
             description=f"Two photon series acquired with {self.channel_name} at plane {self.plane_name}",
-            unit="n.a.",
-            dimension=self.imaging_extractor.get_image_size(),
+            # unit="n.a.",
+            # dimension=self.imaging_extractor.get_image_size(),
         )
 
         return metadata

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -48,8 +48,9 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
         super().__init__(folder_path=folder_path, channel_name=channel_name, plane_name=plane_name, verbose=verbose)
 
     def get_metadata(self) -> DeepDict:
-        device_number = 0  # Imaging plane metadata is a list with metadata for each plane
+        
         metadata = super().get_metadata()
+
         if "state.internal.triggerTimeString" in self.image_metadata:
             extracted_session_start_time = dateparse(self.image_metadata["state.internal.triggerTimeString"])
             metadata["NWBFile"].update(session_start_time=extracted_session_start_time)
@@ -63,6 +64,7 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
             metadata["NWBFile"].update(session_start_time=extracted_session_start_time)
 
         # Extract many scan image properties and attach them as dic in the description
+        device_number = 0  # Imaging plane metadata is a list with metadata for each plane
         ophys_metadata = metadata["Ophys"]
         two_photon_series_metadata = ophys_metadata["TwoPhotonSeries"][device_number]
         if self.image_metadata is not None:
@@ -74,12 +76,12 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
         channel_metadata = {
             "Channel1": {
                 "name": "Green",
-                "emission_lambda": 513.0, # Not specified
+                #"emission_lambda": # Not specified
                 "description": "Green channel of the microscope",
             },
             "Channel2": {
                 "name": "Red",
-                "emission_lambda": 581.0,# Not specified
+                #"emission_lambda": # Not specified
                 "description": "Red channel of the microscope",
             },
         }[channel_name_without_space]
@@ -100,9 +102,9 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
             name=imaging_plane_name,
             optical_channel=[optical_channel_metadata],
             device=device_name,
-            excitation_lambda=920.0,
+            #excitation_lambda=,
             #indicator=indicator,
-            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
+            imaging_rate= float(self.image_metadata["SI.hRoiManager.scanVolumeRate"])
         )
 
         two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
@@ -110,9 +112,10 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
             name=f"TwoPhotonSeries{channel_name_without_space}Plane{self.plane_name}",
             imaging_plane=imaging_plane_name,
             scan_line_rate=1 / float(self.image_metadata["SI.hRoiManager.linePeriod"]),
-            rate=self.imaging_extractor.get_sampling_frequency(),
             description=f"Two photon series acquired with {self.channel_name} at plane {self.plane_name}",
         )
 
         return metadata
 
+    def set_aligned_timestamps(self):
+        self.imaging_extractor._times

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -11,6 +11,7 @@ from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseIma
 from neuroconv.utils import FolderPathType
 from neuroconv.utils.dict import DeepDict
 from roiextractors.extractors.tiffimagingextractors.scanimagetiff_utils import extract_extra_metadata
+from roiextractors.extractors.tiffimagingextractors.scanimagetiffimagingextractor import ScanImageTiffSinglePlaneImagingExtractor
 
 class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
     """
@@ -18,6 +19,16 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
     """
 
     Extractor = Abdeladim2023SinglePlaneImagingExtractor
+
+    @classmethod
+    def get_available_channels(cls, folder_path):
+        file_path = sorted(glob.glob(f"{folder_path}/*.tif"))
+        return ScanImageTiffSinglePlaneImagingExtractor.get_available_channels(file_path=file_path[0])
+
+    @classmethod
+    def get_available_planes(cls, folder_path):
+        file_path = sorted(glob.glob(f"{folder_path}/*.tif"))
+        return ScanImageTiffSinglePlaneImagingExtractor.get_available_planes(file_path=file_path[0]) 
 
     def __init__(
         self,

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023imaginginterface.py
@@ -1,7 +1,7 @@
 from dateutil.parser import parse as dateparse
 import datetime
 import json
-import glob
+from pathlib import Path
 from natsort import natsorted
 from .abdeladim_2023imagingextractor import (
     Abdeladim2023MultiPlaneImagingExtractor,
@@ -30,8 +30,10 @@ class Abdeladim2023SinglePlaneImagingInterface(BaseImagingExtractorInterface):
         self.channel_name = channel_name
         self.plane_name = plane_name
 
-        file_paths = natsorted(glob.glob(f"{folder_path}/*.tif"))
-        self.image_metadata = extract_extra_metadata(file_path=file_paths[0])
+        self.folder_path = Path(folder_path)
+        tif_file_paths = natsorted(self.folder_path.glob("*.tif"))
+        assert tif_file_paths, f"The TIF image files are missing from '{self.folder_path}'."
+        self.image_metadata = extract_extra_metadata(file_path=tif_file_paths[0])
         super().__init__(folder_path=folder_path, channel_name=channel_name, plane_name=plane_name, verbose=verbose)
 
     def get_metadata(self) -> DeepDict:

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
@@ -1,12 +1,53 @@
 """Primary NWBConverter class for this dataset."""
 from neuroconv import NWBConverter
-from neuroconv.datainterfaces import (
-    SpikeGLXRecordingInterface,
-    SpikeGLXLFPInterface,
-    PhySortingInterface,
-)
 
+from neuroconv.utils import FolderPathType
+from neuroconv.datainterfaces.ophys.suite2p.suite2pdatainterface import Suite2pSegmentationInterface
 from abdeladim_2023imaginginterface import Abdeladim2023SinglePlaneImagingInterface
+
+def get_default_segmentation_to_imaging_name_mapping(
+    imaging_folder_path: FolderPathType, segmentation_folder_path: FolderPathType
+) -> dict or None:
+    """
+    Get the default mapping between imaging and segmentation planes.
+
+    Parameters
+    ----------
+    imaging_folder_path: FolderPathType
+        The folder path that contains the ScanImage TIF imaging output (.tif files).
+    segmentation_folder_path: FolderPathType
+        The folder that contains the Suite2P segmentation output. (usually named "suite2p")
+    """
+    si_available_channels = Abdeladim2023SinglePlaneImagingInterface.get_available_channels(
+        folder_path=imaging_folder_path
+    )
+    si_available_channels = [channel_name.replace(" ", "") for channel_name in si_available_channels]
+    si_available_planes = Abdeladim2023SinglePlaneImagingInterface.get_available_planes(folder_path=imaging_folder_path)
+
+    s2p_available_channels = Suite2pSegmentationInterface.get_available_channels(folder_path=segmentation_folder_path)
+    s2p_available_planes = Suite2pSegmentationInterface.get_available_planes(folder_path=segmentation_folder_path)
+
+    if len(s2p_available_channels) == 1 and len(s2p_available_planes) == 1:
+        return None
+
+    segmentation_channel_plane_names = [
+        f"{channel_name.capitalize()}{plane_name.capitalize()}"
+        for channel_name in s2p_available_channels
+        for plane_name in s2p_available_planes 
+    ]
+
+    if len(si_available_planes) > 1:
+       imaging_channel_plane_names = [
+            f"{channel_name.capitalize()}Plane{plane_name.capitalize()}"
+            for channel_name in si_available_channels
+            for plane_name in si_available_planes
+        ]
+    else:
+        imaging_channel_plane_names = si_available_channels
+
+    segmentation_to_imaging_name_mapping = dict(zip(segmentation_channel_plane_names, imaging_channel_plane_names))
+
+    return segmentation_to_imaging_name_mapping
 
 
 class Abdeladim2023NWBConverter(NWBConverter):

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
@@ -6,15 +6,17 @@ from neuroconv.datainterfaces import (
     PhySortingInterface,
 )
 
-from mousev1_to_nwb.abdeladim_2023 import Abdeladim2023BehaviorInterface
+from abdeladim_2023imaginginterface import Abdeladim2023SinglePlaneImagingInterface
 
 
 class Abdeladim2023NWBConverter(NWBConverter):
     """Primary conversion class for my extracellular electrophysiology dataset."""
 
     data_interface_classes = dict(
-        Recording=SpikeGLXRecordingInterface,
-        LFP=SpikeGLXLFPInterface,
-        Sorting=PhySortingInterface,
-        Behavior=Abdeladim2023BehaviorInterface,
+        ImagingChannel1Plane0=Abdeladim2023SinglePlaneImagingInterface,
+        ImagingChannel1Plane1=Abdeladim2023SinglePlaneImagingInterface,
+        ImagingChannel1Plane2=Abdeladim2023SinglePlaneImagingInterface,        
+        ImagingChannel2Plane0=Abdeladim2023SinglePlaneImagingInterface,
+        ImagingChannel2Plane1=Abdeladim2023SinglePlaneImagingInterface,
+        ImagingChannel2Plane2=Abdeladim2023SinglePlaneImagingInterface,
     )

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
@@ -1,9 +1,13 @@
 """Primary NWBConverter class for this dataset."""
+from typing import Dict
 from neuroconv import NWBConverter
 
+"""Primary NWBConverter class for this dataset."""
 from neuroconv.utils import FolderPathType
+from typing import Optional
 from neuroconv.datainterfaces.ophys.suite2p.suite2pdatainterface import Suite2pSegmentationInterface
 from abdeladim_2023imaginginterface import Abdeladim2023SinglePlaneImagingInterface
+
 
 def get_default_segmentation_to_imaging_name_mapping(
     imaging_folder_path: FolderPathType, segmentation_folder_path: FolderPathType
@@ -33,11 +37,11 @@ def get_default_segmentation_to_imaging_name_mapping(
     segmentation_channel_plane_names = [
         f"{channel_name.capitalize()}{plane_name.capitalize()}"
         for channel_name in s2p_available_channels
-        for plane_name in s2p_available_planes 
+        for plane_name in s2p_available_planes
     ]
 
     if len(si_available_planes) > 1:
-       imaging_channel_plane_names = [
+        imaging_channel_plane_names = [
             f"{channel_name.capitalize()}Plane{plane_name.capitalize()}"
             for channel_name in si_available_channels
             for plane_name in si_available_planes
@@ -53,11 +57,62 @@ def get_default_segmentation_to_imaging_name_mapping(
 class Abdeladim2023NWBConverter(NWBConverter):
     """Primary conversion class for my extracellular electrophysiology dataset."""
 
-    data_interface_classes = dict(
-        ImagingChannel1Plane0=Abdeladim2023SinglePlaneImagingInterface,
-        ImagingChannel1Plane1=Abdeladim2023SinglePlaneImagingInterface,
-        ImagingChannel1Plane2=Abdeladim2023SinglePlaneImagingInterface,        
-        ImagingChannel2Plane0=Abdeladim2023SinglePlaneImagingInterface,
-        ImagingChannel2Plane1=Abdeladim2023SinglePlaneImagingInterface,
-        ImagingChannel2Plane2=Abdeladim2023SinglePlaneImagingInterface,
-    )
+    def __init__(
+        self,
+        imaging_folder_path: FolderPathType,
+        segmentation_folder_path: Optional[FolderPathType] = None,
+        segmentation_to_imaging_map: dict = None,
+        verbose: bool = True,
+    ):
+        self.verbose = verbose
+        self.data_interface_objects = dict()
+
+        self.plane_map = segmentation_to_imaging_map
+
+        available_channels = Abdeladim2023SinglePlaneImagingInterface.get_available_channels(
+            folder_path=imaging_folder_path
+        )
+        available_planes = Abdeladim2023SinglePlaneImagingInterface.get_available_planes(
+            folder_path=imaging_folder_path
+        )
+        for channel_name in available_channels:
+            for plane_name in available_planes:
+                channel_name_without_space = channel_name.replace(" ", "")
+                imaging_interface_name = f"Imaging{channel_name_without_space}Plane{plane_name}"
+                imaging_source_data = dict(
+                        folder_path=imaging_folder_path,
+                        channel_name=channel_name,
+                        plane_name=plane_name,
+                        verbose=verbose,
+                )
+                self.data_interface_objects.update(
+                    {imaging_interface_name: Abdeladim2023SinglePlaneImagingInterface(**imaging_source_data)}
+                )
+
+        if segmentation_folder_path:
+            available_planes = Suite2pSegmentationInterface.get_available_planes(folder_path=segmentation_folder_path)
+            available_channels = Suite2pSegmentationInterface.get_available_channels(
+                folder_path=segmentation_folder_path
+            )
+            for channel_name in available_channels:
+                for plane_name in available_planes:
+                    plane_name_suffix = f"{channel_name.capitalize()}{plane_name.capitalize()}"
+                    segmentation_interface_name = f"Segmentation{plane_name_suffix}"
+                    segmentation_source_data = dict(
+                        folder_path=segmentation_folder_path,
+                        channel_name=channel_name,
+                        plane_name=plane_name,
+                        verbose=verbose,
+                    )
+                    if self.plane_map:
+                        plane_segmentation_name = "PlaneSegmentation" + self.plane_map.get(
+                            plane_name_suffix, None
+                        ).replace("_", "")
+                        segmentation_source_data.update(
+                            plane_segmentation_name=plane_segmentation_name,
+                        )
+                    Suite2pSegmentationInterface(**segmentation_source_data)
+                    self.data_interface_objects.update(
+                        {segmentation_interface_name: Suite2pSegmentationInterface(**segmentation_source_data)}
+                    )
+

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023nwbconverter.py
@@ -5,8 +5,8 @@ from neuroconv import NWBConverter
 """Primary NWBConverter class for this dataset."""
 from neuroconv.utils import FolderPathType
 from typing import Optional
-from neuroconv.datainterfaces.ophys.suite2p.suite2pdatainterface import Suite2pSegmentationInterface
 from abdeladim_2023imaginginterface import Abdeladim2023SinglePlaneImagingInterface
+from abdeladim_2023segmentationinterface import Abdeladim2023SegmentationInterface
 
 
 def get_default_segmentation_to_imaging_name_mapping(
@@ -28,8 +28,8 @@ def get_default_segmentation_to_imaging_name_mapping(
     si_available_channels = [channel_name.replace(" ", "") for channel_name in si_available_channels]
     si_available_planes = Abdeladim2023SinglePlaneImagingInterface.get_available_planes(folder_path=imaging_folder_path)
 
-    s2p_available_channels = Suite2pSegmentationInterface.get_available_channels(folder_path=segmentation_folder_path)
-    s2p_available_planes = Suite2pSegmentationInterface.get_available_planes(folder_path=segmentation_folder_path)
+    s2p_available_channels = Abdeladim2023SegmentationInterface.get_available_channels(folder_path=segmentation_folder_path)
+    s2p_available_planes = Abdeladim2023SegmentationInterface.get_available_planes(folder_path=segmentation_folder_path)
 
     if len(s2p_available_channels) == 1 and len(s2p_available_planes) == 1:
         return None
@@ -55,13 +55,15 @@ def get_default_segmentation_to_imaging_name_mapping(
 
 
 class Abdeladim2023NWBConverter(NWBConverter):
-    """Primary conversion class for my extracellular electrophysiology dataset."""
+    """Primary conversion class for Abdeladim2023 dataset."""
 
     def __init__(
         self,
         imaging_folder_path: FolderPathType,
         segmentation_folder_path: Optional[FolderPathType] = None,
         segmentation_to_imaging_map: dict = None,
+        segmentation_start_frame: int = 0,
+        segmentation_end_frame: int = 100,
         verbose: bool = True,
     ):
         self.verbose = verbose
@@ -90,8 +92,8 @@ class Abdeladim2023NWBConverter(NWBConverter):
                 )
 
         if segmentation_folder_path:
-            available_planes = Suite2pSegmentationInterface.get_available_planes(folder_path=segmentation_folder_path)
-            available_channels = Suite2pSegmentationInterface.get_available_channels(
+            available_planes = Abdeladim2023SegmentationInterface.get_available_planes(folder_path=segmentation_folder_path)
+            available_channels = Abdeladim2023SegmentationInterface.get_available_channels(
                 folder_path=segmentation_folder_path
             )
             for channel_name in available_channels:
@@ -102,6 +104,8 @@ class Abdeladim2023NWBConverter(NWBConverter):
                         folder_path=segmentation_folder_path,
                         channel_name=channel_name,
                         plane_name=plane_name,
+                        start_frame=segmentation_start_frame,
+                        end_frame=segmentation_end_frame,
                         verbose=verbose,
                     )
                     if self.plane_map:
@@ -111,8 +115,8 @@ class Abdeladim2023NWBConverter(NWBConverter):
                         segmentation_source_data.update(
                             plane_segmentation_name=plane_segmentation_name,
                         )
-                    Suite2pSegmentationInterface(**segmentation_source_data)
+                    Abdeladim2023SegmentationInterface(**segmentation_source_data)
                     self.data_interface_objects.update(
-                        {segmentation_interface_name: Suite2pSegmentationInterface(**segmentation_source_data)}
+                        {segmentation_interface_name: Abdeladim2023SegmentationInterface(**segmentation_source_data)}
                     )
 

--- a/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023segmentationinterface.py
+++ b/src/mousev1_to_nwb/abdeladim_2023/abdeladim_2023segmentationinterface.py
@@ -1,0 +1,25 @@
+from neuroconv.datainterfaces.ophys.basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from roiextractors.extractors.suite2p.suite2psegmentationextractor import Suite2pSegmentationExtractor
+from neuroconv.utils import DeepDict, FolderPathType
+from neuroconv.datainterfaces.ophys.suite2p.suite2pdatainterface import Suite2pSegmentationInterface
+
+class Abdeladim2023SegmentationInterface(Suite2pSegmentationInterface):
+    """
+    Data Interface for writing imaging data for the MouseV1 to NWB file using Abdeladim2023SinglePlaneImagingExtractor.
+    """
+
+    Extractor = Suite2pSegmentationExtractor
+
+    def __init__(
+        self,
+        folder_path: FolderPathType,
+        channel_name: str,
+        plane_name: str,
+        plane_segmentation_name: str,
+        start_frame: int,
+        end_frame: int,
+        verbose: bool = True,
+    ):
+        
+        super().__init__(folder_path=folder_path, channel_name=channel_name, plane_name=plane_name, plane_segmentation_name=plane_segmentation_name, verbose=verbose)
+        self.segmentation_extractor=self.segmentation_extractor.frame_slice(start_frame=start_frame,end_frame=end_frame)


### PR DESCRIPTION
This PR is for adding the imaging extractor (edit: Now it is including also the imaging interface #5  and the segmentation interface #6 )
I am working with a ScanImage dataset where a single session recording is chunked over time in multiple .tif files.
Currently, the ScanImage extractor extracts the entire video from one .tif file.
I need to pass a folder_path where all the .tif files of one session are stored-

- [x] add multi plane imaging extractor
- [x] add single plane imaging extractor
- [ ] separate segmentation data into epochs (same as raw imaging)
